### PR TITLE
Support for Firefox-based browsers

### DIFF
--- a/OpenInWSA/Managers/BrowserManager.cs
+++ b/OpenInWSA/Managers/BrowserManager.cs
@@ -246,7 +246,7 @@ namespace OpenInWSA.Managers
                 return;
             }
 
-            command = command.Replace("%1", url);
+            command = command.Replace("\"%1\"", url).Replace("%1", url);
             var info = new ProcessStartInfo("cmd", $"/c {command}")
             {
                 UseShellExecute = false,


### PR DESCRIPTION
Firefox-based browsers seem to add quotation marks around %1 in shell/open/command. 
`"C:\Program Files\Mozilla Firefox\firefox.exe" -osint -url "%1"`

Chromium-based browsers do not.
`"C:\Program Files\Google\Chrome Dev\Application\chrome.exe" --single-argument %1`

This PR simply adds a search for `"%1"` and replaces it with the url. If it does not find `"%1"` then it moves on and looks for `%1`.

I tested this on Edge, Chrome, Firefox, and Waterfox and links successfully opened in all of them. 

Resolves #3 