### PR TITLE
Fix #3 by quoting double quotes

### DIFF
--- a/OpenInWSA/Managers/BrowserManager.cs
+++ b/OpenInWSA/Managers/BrowserManager.cs
@@ -247,7 +247,7 @@ namespace OpenInWSA.Managers
             }
 
             command = command.Replace("%1", url);
-            var info = new ProcessStartInfo("cmd", $"/c {command}")
+            var info = new ProcessStartInfo("cmd", $@"/c ""{command}""")
             {
                 UseShellExecute = false,
                 CreateNoWindow = true


### PR DESCRIPTION
#3 is caused by cmd removing quotes from commands under there conditions documented [here](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#:~:text=You%20use%20exactly%20one%20set%20of%20quotation%20marks), specifically when there are multiple sets of quotes. 

This fix surrounds the entire command with quotes so that nothing is changed.